### PR TITLE
Fixed syntax error on skills.py

### DIFF
--- a/skills.py
+++ b/skills.py
@@ -61,12 +61,14 @@ selected_skill = input("Enter the code of a skill: ")
 edges = skills_graph.edges(selected_skill, data=True)
 edges = sorted(edges, reverse=True, key=lambda edge: edge[2].get('weight', 1))
 
-print(f'\nOften used skills with "{skills_graph.nodes[selected_skill]['label']} ({selected_skill})":')
+print(f"\nOften used skills with \"{skills_graph.nodes[selected_skill]['label']} ({selected_skill})\":")
 occupations_selected = skills_graph.nodes[selected_skill]["occupations"]
 for edge in edges[:10]:
     occupations = skills_graph.nodes[edge[1]]['occupations']
     intersection = sorted(list(set(occupations_selected) & set(occupations)), reverse=True, key=lambda prof: prof[1])
-    print(f'"{skills_graph.nodes[edge[1]]['label']} ({edge[1]})" e.g. as {", ".join([f'{occup[0]} ({occup[1]})' for occup in intersection[:5]])}')
+    print(f"\"{skills_graph.nodes[edge[1]]['label']} ({edge[1]})\" " 
+    f"e.g. as {', '.join([f'{occup[0]} ({occup[1]})' for occup in intersection[:5]])}"
+    )
     print("\n")
 
 


### PR DESCRIPTION
Getting the following error on attempted compile test. Test was ran on Windows PC using Git Bash with a virtual environment running python 3.10. ---------------------------------------------------------------------------------------------------------- $ python -m py_compile skills.py
  File "skills.py", line 64
    print(f'\nOften used skills with "{skills_graph.nodes[selected_skill]['label']} ({selected_skill})":')
                                                                                                            ^^^^^
SyntaxError: f-string: unmatched '['
(venv)
----------------------------------------------------------------------------------------------------------

Found that this error was due to improper nested single and double quotation marks in the print command. Adjusted single vs double quotation marks such that skills.py will now compile.